### PR TITLE
Change CMake default thread count

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM gcc:11.2.0 as build
 # 171022 = Unmodded Client
 # 171023 = DLU Client
 ARG BUILD_VERSION=171022
-ARG BUILD_ARGS=-j12
+ARG BUILD_ARGS=-j8
 
 # Working Directory
 WORKDIR /opt/darkflame-universe


### PR DESCRIPTION
12 threads is excessive for systems without higher end processors, but I think 4 cores w/ 8 threads is standard enough to be a reasonable default. Definitely something to mention in the PDF either way, but it should probably be set to what most systems use by default.